### PR TITLE
Update to bundle check logic to check for 'RELEASED' status

### DIFF
--- a/setup.sql
+++ b/setup.sql
@@ -11,7 +11,7 @@ BEGIN
   SYSTEM$LOG_INFO('Bundle 2025_01 is ' || :status_2025_01);
   
   -- Check if the bundle is ENABLED and execute appropriate commands
-  IF (status_2025_01 = 'ENABLED') THEN
+  IF (status_2025_01 = 'ENABLED' OR status_2025_01 = 'RELEASED') THEN
 
     -- Create Streamlit with multifile editing
     CREATE STREAMLIT CORTEX_AGENT_CHAT_APP


### PR DESCRIPTION
Updated bundle check logic to account for future state when the status of 'RELEASED' is possible. This happens when a bundle can no longer be disabled.