### PR TITLE
Update setup.sql

### DIFF
--- a/setup.sql
+++ b/setup.sql
@@ -1,49 +1,59 @@
+-- Set the current role to ACCOUNTADMIN
 USE ROLE ACCOUNTADMIN;
 
--- Fetch most recent files from Github repository
+-- Fetch the most recent files from the specified Github repository
 ALTER GIT REPOSITORY GITHUB_REPO_CORTEX_AGENTS_DEMO FETCH;
 
--- Create Streamlit app with method based on status of Behavior Change Bundle 2025_01
+-- Create a Streamlit app based on the status of Behavior Change Bundle 2025_01
 BEGIN
-  -- Check if 2025 Bundle is enabled (multi-page streamlit apps)
+  -- Check if 2025 Bundle is enabled (for multi-page Streamlit apps)
   LET status_2025_01 STRING := (SELECT SYSTEM$BEHAVIOR_CHANGE_BUNDLE_STATUS('2025_01'));
-  -- Log result
+  
+  -- Log the bundle status
   SYSTEM$LOG_INFO('Bundle 2025_01 is ' || :status_2025_01);
   
-  -- Check if the bundle is ENABLED and execute appropriate commands
+  -- Check if the bundle is ENABLED or RELEASED and execute appropriate commands
   IF (status_2025_01 = 'ENABLED' OR status_2025_01 = 'RELEASED') THEN
+    -- If bundle 2025_01 is DISABLED, the compiler won't recognize the new CREATE STREAMLIT syntax
+    -- To work around this, the statement is stored in a string variable
+    let smt string := $$
+      -- Create Streamlit app with multi-file editing support
+      CREATE OR REPLACE STREAMLIT CORTEX_AGENT_CHAT_APP
+        FROM @CORTEX_AGENTS_DEMO.PUBLIC.GITHUB_REPO_CORTEX_AGENTS_DEMO/branches/main/agent_app/
+        MAIN_FILE = 'app.py'
+        QUERY_WAREHOUSE = COMPUTE_WH
+        TITLE = 'Cortex Agents Chat App'
+        COMMENT = 'Demo Streamlit frontend for Cortex Agents'
+    $$;
 
-    -- Create Streamlit with multifile editing
-    CREATE STREAMLIT CORTEX_AGENT_CHAT_APP
-      FROM @CORTEX_AGENTS_DEMO.PUBLIC.GITHUB_REPO_CORTEX_AGENTS_DEMO/branches/main/agent_app/
-      MAIN_FILE = 'app.py'
-      QUERY_WAREHOUSE = COMPUTE_WH
-      TITLE = 'Cortex Agents Chat App'
-      COMMENT = 'Demo Streamlit frontend for Cortex Agents';
+    -- Execute the CREATE STREAMLIT statement
+    EXECUTE IMMEDIATE :smt;
 
     RETURN 'Bundle 2025_01 is ENABLED. Created Streamlit app with multi-file editing.';
+    
   ELSE
-    -- Check if the bundle is DISABLED and execute appropriate commands
-      -- Create stage for the Streamlit App
-      CREATE OR REPLACE STAGE STREAMLIT_APP
-        DIRECTORY = (ENABLE = TRUE)
-        ENCRYPTION = ( TYPE = 'SNOWFLAKE_FULL' );
+    -- If the bundle is DISABLED, execute these commands for single-file editing
+    -- Create a stage for the Streamlit App
+    CREATE OR REPLACE STAGE STREAMLIT_APP
+      DIRECTORY = (ENABLE = TRUE)
+      ENCRYPTION = ( TYPE = 'SNOWFLAKE_FULL' );
 
-      -- Copy Streamlit App into to stage
-      COPY FILES
-        INTO @STREAMLIT_APP
-        FROM @CORTEX_AGENTS_DEMO.PUBLIC.GITHUB_REPO_CORTEX_AGENTS_DEMO/branches/main/agent_app/;
-      ALTER STAGE STREAMLIT_APP REFRESH;
+    -- Copy Streamlit App files into the stage
+    COPY FILES
+      INTO @STREAMLIT_APP
+      FROM @CORTEX_AGENTS_DEMO.PUBLIC.GITHUB_REPO_CORTEX_AGENTS_DEMO/branches/main/agent_app/;
+    
+    -- Refresh the stage to reflect the new files
+    ALTER STAGE STREAMLIT_APP REFRESH;
 
-      -- Create Streamlit App
-      CREATE OR REPLACE STREAMLIT CORTEX_AGENT_CHAT_APP
-          ROOT_LOCATION = '@CORTEX_AGENTS_DEMO.PUBLIC.STREAMLIT_APP'
-          MAIN_FILE = '/app.py'
-          QUERY_WAREHOUSE = COMPUTE_WH
-          TITLE = 'Cortex Agents Chat App'
-          COMMENT = 'Demo Streamlit frontend for Cortex Agents';
+    -- Create Streamlit App with single-file editing
+    CREATE OR REPLACE STREAMLIT CORTEX_AGENT_CHAT_APP
+        ROOT_LOCATION = '@CORTEX_AGENTS_DEMO.PUBLIC.STREAMLIT_APP'
+        MAIN_FILE = '/app.py'
+        QUERY_WAREHOUSE = 'COMPUTE_WH'
+        TITLE = 'Cortex Agents Chat App'
+        COMMENT = 'Demo Streamlit frontend for Cortex Agents';
 
-      RETURN 'Bundle 2025_01 is DISABLED. Created Streamlit app with single file editing.';
+    RETURN 'Bundle 2025_01 is DISABLED. Created Streamlit app with single file editing.';
   END IF;
-END;
-
+END


### PR DESCRIPTION
The updated code addresses a syntax compatibility issue between different Snowflake parameters (2025_01):
**When Bundle 2025_01 is DISABLED:**
The compiler doesn't recognize the newer `CREATE STREAMLIT` syntax (the one with direct GitHub repository reference)
Even though this code is in the IF block and _**wouldn't**_ execute, the compiler still checks it and throws a syntax error

**The Solution**
To solve this problem, the code uses a workaround:

- The newer `CREATE STREAMLIT` syntax is now stored as a string variable (`:smt`)
- This string is only executed via `EXECUTE IMMEDIATE` when the bundle is ENABLED
- When the bundle is DISABLED, the code follows the ELSE path with the older syntax

This approach effectively "hides" the newer syntax from the compiler's initial syntax checking phase. The compiler only sees a string variable assignment, which is valid syntax in both bundle versions.

**The solution works reliably regardless of bundle status:**

- With Bundle 2025_01 **ENABLED**: Creates a multi-page Streamlit app directly from the GitHub repository
- With Bundle 2025_01 **DISABLED**: Creates a single-page Streamlit app using a stage dependency