### PR TITLE
Bug Fix: Prevent raising a SQL error if a stage name for a semantic file has spaces or special characters 

### DIFF
--- a/agent_app/app.py
+++ b/agent_app/app.py
@@ -1823,7 +1823,7 @@ def manage_analyst_services():
         
         # Fetch files directly without caching
         try:
-            files = session.sql(f'LS @"{database}"."{schema}"."{stage}"').filter(
+            files = session.sql(f"LS '@\"{database}\".\"{schema}\".\"{stage}\"'").filter(
                 col('"size"') < 1000000
             ).filter(
                 (lower(col('"name"')).endswith('.yaml')) | 


### PR DESCRIPTION
Bug Fix: Prevent raising an error if a stage name for a semantic file has spaces or special characters in the Select Analyst Service dialog box. 

**Example Failing Query:**

`LS @"ADMIN_DB"."PUBLIC"."Billing Metrics (Stage)"`

_**Error Returned in Streamlit:**_

`SQL compilation error: syntax error line 1 at position 41 unexpected '('. syntax error line 1 at position 48 unexpected '"'.`


**Example Successful Query after updated code:**

`LS '@"ADMIN_DB"."PUBLIC"."Billing Metrics (Stage)"'`

The solution is to wrap the entire fully qualified stage name in single quotes. (including `@` prefix) when calling LS (list)